### PR TITLE
Fix: clients cannot communicate with server on production

### DIFF
--- a/controllers/account.mjs
+++ b/controllers/account.mjs
@@ -88,6 +88,7 @@ async function postLogIn(req, res, next) {
         httpOnly: true,
         secure: process.env.SECURE_COOKIES,
         sameSite: 'none',
+        partitioned: true,
         // Expire in 28 days just like the refresh token.
         // Now refresh token is pulled in from env file, just set this to a year or something stupid?
         // The refresh token will expire long before the cookie anyway.
@@ -99,6 +100,7 @@ async function postLogIn(req, res, next) {
         httpOnly: false,
         secure: process.env.SECURE_COOKIES,
         sameSite: 'none',
+        partitioned: true,
         expires: cookieExpTime,
       });
 

--- a/controllers/account.mjs
+++ b/controllers/account.mjs
@@ -87,7 +87,7 @@ async function postLogIn(req, res, next) {
       res.cookie('refresh', refresh, {
         httpOnly: true,
         secure: process.env.SECURE_COOKIES,
-        sameSite: 'strict',
+        sameSite: 'none',
         // Expire in 28 days just like the refresh token.
         // Now refresh token is pulled in from env file, just set this to a year or something stupid?
         // The refresh token will expire long before the cookie anyway.
@@ -98,7 +98,7 @@ async function postLogIn(req, res, next) {
       res.cookie('login', 'true', {
         httpOnly: false,
         secure: process.env.SECURE_COOKIES,
-        sameSite: 'strict',
+        sameSite: 'none',
         expires: cookieExpTime,
       });
 


### PR DESCRIPTION
Due to CORS issues. Should be solved by cors middleware, but apparently not. Perhaps fetch requests need ```mode: 'cors'``` added?