### PR TITLE
Add api routes to manage images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ dist
 generated/
 
 TODO.md
+
+# Static dir for testing file uploads.
+static/

--- a/.prettierignore
+++ b/.prettierignore
@@ -140,3 +140,6 @@ dist
 
 # Prisma generated files
 generated/
+
+# Static dir for testing file uploads.
+static/

--- a/app.mjs
+++ b/app.mjs
@@ -13,7 +13,7 @@ const app = express();
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 app.use(
-  '/' + process.env.SERVER_STATIC_DIR,
+  process.env.SERVER_STATIC_DIR,
   express.static(process.env.VOLUME_MOUNT_PATH),
 );
 

--- a/app.mjs
+++ b/app.mjs
@@ -12,6 +12,10 @@ import 'dotenv/config';
 const app = express();
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
+app.use(
+  '/' + process.env.SERVER_STATIC_DIR,
+  express.static(process.env.VOLUME_MOUNT_PATH),
+);
 
 // REST tools will have no origin, so allow for that with !origin.
 const whitelist = Array.from(

--- a/controllers/images.mjs
+++ b/controllers/images.mjs
@@ -22,6 +22,37 @@ async function getImages(req, res, next) {
   }
 }
 
+async function getImage(req, res, next) {
+  try {
+    const image = await db.image.findUnique({
+      where: {
+        id: req.params.id,
+      },
+    });
+
+    if (!image) {
+      return res.status(404).json({
+        status: 'fail',
+        data: {
+          message: 'Image not found',
+        },
+      });
+    }
+
+    return res.json({
+      status: 'success',
+      data: {
+        image: {
+          ...image,
+          url: createStaticUrl(image.fileName),
+        },
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
 async function postImage(req, res, next) {
   try {
     const result = validationResult(req);
@@ -80,4 +111,4 @@ async function postImage(req, res, next) {
   }
 }
 
-export { getImages, postImage };
+export { getImages, getImage, postImage };

--- a/controllers/images.mjs
+++ b/controllers/images.mjs
@@ -1,0 +1,65 @@
+import createStaticUrl from '../helpers/createStaticUrl.mjs';
+import formatValidationErrors from '../helpers/formatValidationErrors.mjs';
+import db from '../db/prismaClient.mjs';
+import { validationResult, matchedData } from 'express-validator';
+import fs from 'node:fs/promises';
+
+async function postImage(req, res, next) {
+  try {
+    const result = validationResult(req);
+
+    if (!result.isEmpty() || !req.file) {
+      // If image uploaded by multer, delete it. Otherwise there will be a file on
+      // the volume which we have no db entry for and won't be able to delete easily.
+      if (req.file) {
+        await fs.rm(req.file.path);
+      }
+
+      const validationErrors = result.array();
+
+      // Validator can only do strings - need to check for the file manually here.
+      if (!req.file) {
+        validationErrors.push({
+          path: 'image',
+          msg: 'An image is required',
+        });
+      }
+
+      return res.status(400).json({
+        status: 'fail',
+        data: {
+          validationErrors: formatValidationErrors(validationErrors),
+        },
+      });
+    }
+
+    const { altText, displayName } = matchedData(req);
+
+    // Create entry on database. Url should not contain entire path but just internal to volume.
+    // That way, if the volume changes, the url will still be correct and not hardcoded into the db entries.
+    const image = await db.image.create({
+      data: {
+        ownerId: req.user.id,
+        fileName: req.file.filename,
+        displayName,
+        altText,
+      },
+    });
+
+    return res.json({
+      status: 'success',
+      data: {
+        message: 'Image posted successfully',
+        image: {
+          ...image,
+          url: createStaticUrl(image.fileName),
+        },
+        file: req.file,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+export { postImage };

--- a/controllers/images.mjs
+++ b/controllers/images.mjs
@@ -1,6 +1,7 @@
 import createStaticUrl from '../helpers/createStaticUrl.mjs';
 import formatValidationErrors from '../helpers/formatValidationErrors.mjs';
 import db from '../db/prismaClient.mjs';
+import * as volume from '../helpers/volume.mjs';
 import { validationResult, matchedData } from 'express-validator';
 import fs from 'node:fs/promises';
 
@@ -61,7 +62,7 @@ async function postImage(req, res, next) {
       // If image uploaded by multer, delete it. Otherwise there will be a file on
       // the volume which we have no db entry for and won't be able to delete easily.
       if (req.file) {
-        await fs.rm(req.file.path);
+        await volume.deleteFile(req.file.filename);
       }
 
       const validationErrors = result.array();
@@ -135,7 +136,7 @@ async function putImage(req, res, next) {
       // If a new image has been uploaded, delete it.
       // The db entry won't get updated, so it needs to go.
       if (req.file) {
-        await fs.rm(req.file.path);
+        await volume.deleteFile(req.file.filename);
       }
 
       return res.status(400).json({
@@ -150,7 +151,7 @@ async function putImage(req, res, next) {
 
     // If a new image has been uploaded, delete the old one from the volume, then update the db.
     if (req.file) {
-      await fs.rm(`${process.env.VOLUME_MOUNT_PATH}/${existingImage.fileName}`);
+      await volume.deleteFile(existingImage.fileName);
       // Add onto matched data so the db entry gets updated with the new file name.
       data.fileName = req.file.filename;
     }

--- a/controllers/images.mjs
+++ b/controllers/images.mjs
@@ -4,6 +4,24 @@ import db from '../db/prismaClient.mjs';
 import { validationResult, matchedData } from 'express-validator';
 import fs from 'node:fs/promises';
 
+async function getImages(req, res, next) {
+  try {
+    const images = await db.image.findMany();
+
+    return res.json({
+      status: 'success',
+      data: {
+        images: images.map((image) => ({
+          ...image,
+          url: createStaticUrl(image.fileName),
+        })),
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
 async function postImage(req, res, next) {
   try {
     const result = validationResult(req);
@@ -62,4 +80,4 @@ async function postImage(req, res, next) {
   }
 }
 
-export { postImage };
+export { getImages, postImage };

--- a/controllers/images.mjs
+++ b/controllers/images.mjs
@@ -3,7 +3,6 @@ import formatValidationErrors from '../helpers/formatValidationErrors.mjs';
 import db from '../db/prismaClient.mjs';
 import * as volume from '../helpers/volume.mjs';
 import { validationResult, matchedData } from 'express-validator';
-import fs from 'node:fs/promises';
 
 async function getImages(req, res, next) {
   try {

--- a/helpers/createStaticUrl.mjs
+++ b/helpers/createStaticUrl.mjs
@@ -1,5 +1,5 @@
 function createStaticUrl(filename) {
-  return `${process.env.SERVER_BASE_URL}/${process.env.SERVER_STATIC_DIR}/${filename}`;
+  return `${process.env.SERVER_BASE_URL}${process.env.SERVER_STATIC_DIR}/${filename}`;
 }
 
 export default createStaticUrl;

--- a/helpers/createStaticUrl.mjs
+++ b/helpers/createStaticUrl.mjs
@@ -1,0 +1,5 @@
+function createStaticUrl(filename) {
+  return `${process.env.SERVER_BASE_URL}/${process.env.SERVER_STATIC_DIR}/${filename}`;
+}
+
+export default createStaticUrl;

--- a/helpers/volume.mjs
+++ b/helpers/volume.mjs
@@ -1,0 +1,7 @@
+import fs from 'node:fs/promises';
+
+async function deleteFile(filepath) {
+  await fs.rm(`${process.env.VOLUME_MOUNT_PATH}/${filepath}`);
+}
+
+export { deleteFile };

--- a/middleware/multer.mjs
+++ b/middleware/multer.mjs
@@ -1,0 +1,13 @@
+import multer from 'multer';
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, process.env.VOLUME_MOUNT_PATH);
+  },
+  filename: (req, file, cb) => {
+    const uniquePrefix = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    cb(null, uniquePrefix + '-' + file.originalname);
+  },
+});
+
+export default multer({ storage });

--- a/middleware/validators.mjs
+++ b/middleware/validators.mjs
@@ -133,6 +133,9 @@ function createImageDisplayNameChain() {
     .custom(async (value, { req }) => {
       const existing = await db.image.findUnique({
         where: {
+          NOT: {
+            id: req.params.id,
+          },
           ownerId_displayName: {
             ownerId: req.user.id,
             displayName: value,

--- a/middleware/validators.mjs
+++ b/middleware/validators.mjs
@@ -121,6 +121,39 @@ function createNewUserChain() {
   return [createUserChain(), password(), confirmPassword()];
 }
 
+function createImageAltTextChain() {
+  return body('altText').trim().notEmpty().withMessage('Alt text is required');
+}
+
+function createImageDisplayNameChain() {
+  return body('displayName')
+    .trim()
+    .notEmpty()
+    .withMessage('A display name is required')
+    .custom(async (value, { req }) => {
+      const existing = await db.image.findUnique({
+        where: {
+          ownerId_displayName: {
+            ownerId: req.user.id,
+            displayName: value,
+          },
+        },
+      });
+      if (existing) throw new Error('Display name already used by this user');
+    });
+}
+
+function createNewImageChain() {
+  return [createImageAltTextChain(), createImageDisplayNameChain()];
+}
+
+function createPutImageChain() {
+  return [
+    createImageAltTextChain().optional(),
+    createImageDisplayNameChain().optional(),
+  ];
+}
+
 export {
   email,
   password,
@@ -132,4 +165,6 @@ export {
   createCommentChain,
   createUserChain,
   createNewUserChain,
+  createNewImageChain,
+  createPutImageChain,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "express": "^5.1.0",
         "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
+        "multer": "^2.0.2",
         "url-query-to-prisma": "^2.0.2"
       },
       "devDependencies": {
@@ -1011,6 +1012,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1074,6 +1081,23 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1188,6 +1212,21 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -3283,11 +3322,93 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -3568,6 +3689,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3799,6 +3934,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3880,6 +4032,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.8.3",
@@ -3991,6 +4149,12 @@
         "path-to-nested-obj": "^1.0.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/validator": {
       "version": "13.15.26",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
@@ -4040,6 +4204,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "express": "^5.1.0",
     "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^2.0.2",
     "url-query-to-prisma": "^2.0.2"
   }
 }

--- a/prisma/migrations/20260105164134_add_image_model/migration.sql
+++ b/prisma/migrations/20260105164134_add_image_model/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "Image" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "fileName" TEXT NOT NULL,
+    "altText" TEXT NOT NULL,
+    "ownerId" TEXT NOT NULL,
+
+    CONSTRAINT "Image_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_BlogToImage" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_BlogToImage_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_BlogToImage_B_index" ON "_BlogToImage"("B");
+
+-- AddForeignKey
+ALTER TABLE "Image" ADD CONSTRAINT "Image_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_BlogToImage" ADD CONSTRAINT "_BlogToImage_A_fkey" FOREIGN KEY ("A") REFERENCES "Blog"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_BlogToImage" ADD CONSTRAINT "_BlogToImage_B_fkey" FOREIGN KEY ("B") REFERENCES "Image"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260107135932_add_image_display_name/migration.sql
+++ b/prisma/migrations/20260107135932_add_image_display_name/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[fileName]` on the table `Image` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[ownerId,displayName]` on the table `Image` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `displayName` to the `Image` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Image" ADD COLUMN     "displayName" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Image_fileName_key" ON "Image"("fileName");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Image_ownerId_displayName_key" ON "Image"("ownerId", "displayName");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,14 +64,19 @@ model Comment {
 }
 
 model Image {
-  id        String   @id @default(uuid())
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  fileName  String
-  altText   String
-  ownerId   String
-  owner     User     @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  id          String   @id @default(uuid())
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  displayName String
+  fileName    String   @unique
+  altText     String
+  ownerId     String
+  owner       User     @relation(fields: [ownerId], references: [id], onDelete: Cascade)
   // Keep track of what blogs use the image, so user can tell how many blogs use 
   // the image, or server can delete an image that is no longer used in any blogs.
-  blogs     Blog[]
+  blogs       Blog[]
+
+  // So each user's photos must have unique display names, but if
+  // multiple owners have photos with the same name, that's fine.
+  @@unique([ownerId, displayName])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,13 @@ model User {
   isBanned  Boolean   @default(false)
   blogs     Blog[]
   comments  Comment[]
+  images    Image[]
+}
+
+model RevokedToken {
+  id        String   @id @default(uuid())
+  token     String
+  expiresAt DateTime
 }
 
 model Blog {
@@ -39,6 +46,7 @@ model Blog {
   comments    Comment[]
   ownerId     String
   owner       User      @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  images      Image[]
 }
 
 model Comment {
@@ -55,8 +63,15 @@ model Comment {
   blog            Blog      @relation(fields: [blogId], references: [id], onDelete: Cascade)
 }
 
-model RevokedToken {
+model Image {
   id        String   @id @default(uuid())
-  token     String
-  expiresAt DateTime
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  fileName  String
+  altText   String
+  ownerId   String
+  owner     User     @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  // Keep track of what blogs use the image, so user can tell how many blogs use 
+  // the image, or server can delete an image that is no longer used in any blogs.
+  blogs     Blog[]
 }

--- a/routers/admin/admin.mjs
+++ b/routers/admin/admin.mjs
@@ -4,6 +4,7 @@ import adminAccountRouter from './adminAccount.mjs';
 import adminBlogsRouter from './adminBlogs.mjs';
 import adminCommentsRouter from './adminComments.mjs';
 import adminUsersRouter from './adminUsers.mjs';
+import adminImagesRouter from './adminImages.mjs';
 import authRouter from '../auth.mjs';
 
 import { Router } from 'express';
@@ -50,5 +51,6 @@ app.use(
 app.use('/blogs', adminBlogsRouter);
 app.use('/comments', adminCommentsRouter);
 app.use('/users', adminUsersRouter);
+app.use('/images', adminImagesRouter);
 
 export default app;

--- a/routers/admin/adminImages.mjs
+++ b/routers/admin/adminImages.mjs
@@ -1,0 +1,25 @@
+import * as controller from '../../controllers/images.mjs';
+import * as validators from '../../middleware/validators.mjs';
+import upload from '../../middleware/multer.mjs';
+import { Router } from 'express';
+
+const app = Router();
+
+app.get('/', controller.getImages);
+app.post(
+  '/',
+  upload.single('image'),
+  validators.createNewImageChain(),
+  controller.postImage,
+);
+
+app.get('/:id', controller.getImage);
+app.put(
+  '/:id',
+  upload.single('image'),
+  validators.createPutImageChain(),
+  controller.putImage,
+);
+app.delete('/:id', controller.deleteImage);
+
+export default app;


### PR DESCRIPTION
Now admin client will be able to get, post, put and delete images to the server.
The database stores the metadata about the images including filenames as stored on the server volume.
The get request turns the filename into a url that can be accessed by the clients (i.e. so clients can access the static asset). the url is not stored on the database itself but generated based on the filename, server domain, and volume path. So even if the domain or volume path changes, we can just change the env variables to generate the correct url.

The idea is the admin client can upload images to the server volume, then easily add the resulting static url to markdown which is currently being edited. Huh... so even if the url generated by the server correctly points to the file even if the domain or volume path has changed, the markdown is saved to the database, and the url gets hardcoded. Hmm. So that isn't actually a benefit.

Well anyway, we can get, post, put and delete images now!