### PR TITLE
Fix images broken urls

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -46,6 +46,16 @@ app.use((error, req, res, next) => {
   // Try to use this only as a last resort. Other more specific responses
   // (e.g. 400, 401, 403) should be provided by other routes.
   console.error(error);
+
+  // Handle multer file size error here since there seems to be no other place to catch it.
+  // Default message is just 'file too large', which isn't very useful for the user.
+  if (error.code === 'LIMIT_FILE_SIZE') {
+    return res.status(413).json({
+      status: 'error',
+      message: `File too large - maximum file size is ${process.env.UPLOAD_MAX_SIZE_MB}MB`,
+    });
+  }
+
   return res.status(500).json({
     status: 'error',
     message: error.message,

--- a/controllers/images.mjs
+++ b/controllers/images.mjs
@@ -233,6 +233,24 @@ async function deleteImage(req, res, next) {
       });
     }
 
+    const blogs = await db.blog.findMany({
+      where: {
+        images: {
+          some: existingImage,
+        },
+      },
+    });
+
+    // If image is used in any blogs, abort deletion.
+    if (blogs.length > 0) {
+      return res.status(400).json({
+        status: 'fail',
+        data: {
+          message: `Cannot delete image while it is used in blogs: ${blogs.length} blogs use this image`,
+        },
+      });
+    }
+
     try {
       // If image exists, delete the file it points to.
       // If no file exists, this will throw an error.

--- a/controllers/images.mjs
+++ b/controllers/images.mjs
@@ -1,7 +1,9 @@
+import db from '../db/prismaClient.mjs';
 import createStaticUrl from '../helpers/createStaticUrl.mjs';
 import formatValidationErrors from '../helpers/formatValidationErrors.mjs';
-import db from '../db/prismaClient.mjs';
 import * as volume from '../helpers/volume.mjs';
+import { createMarkdownImgLinkRegExp } from '../helpers/regexp.mjs';
+
 import { validationResult, matchedData } from 'express-validator';
 
 async function getImages(req, res, next) {
@@ -156,6 +158,18 @@ async function putImage(req, res, next) {
       where: {
         id: req.params.id,
       },
+      include: {
+        blogs: {
+          orderBy: [
+            {
+              updatedAt: 'desc',
+            },
+            {
+              id: 'asc',
+            },
+          ],
+        },
+      },
     });
 
     if (!existingImage) {
@@ -199,6 +213,25 @@ async function putImage(req, res, next) {
       },
       data,
     });
+
+    for (const blog of existingImage.blogs) {
+      // Replace links to existing image with location of new image, any updated alt text, etc.
+      const oldLinkRegExp = createMarkdownImgLinkRegExp(
+        createStaticUrl(existingImage.fileName),
+        null,
+        'g',
+      );
+      const newLink = `![${updated.altText}](${createStaticUrl(updated.fileName)})`;
+      const updatedBody = blog.body.replaceAll(oldLinkRegExp, newLink);
+      await db.blog.update({
+        where: {
+          id: blog.id,
+        },
+        data: {
+          body: updatedBody,
+        },
+      });
+    }
 
     return res.json({
       status: 'success',

--- a/helpers/createStaticUrl.mjs
+++ b/helpers/createStaticUrl.mjs
@@ -1,5 +1,8 @@
 function createStaticUrl(filename) {
-  return `${process.env.SERVER_BASE_URL}${process.env.SERVER_STATIC_DIR}/${filename}`;
+  return new URL(
+    `${process.env.SERVER_STATIC_DIR}/${filename}`,
+    process.env.SERVER_BASE_URL,
+  );
 }
 
 export default createStaticUrl;

--- a/helpers/getFileExtFromMimeType.mjs
+++ b/helpers/getFileExtFromMimeType.mjs
@@ -1,0 +1,7 @@
+export default function getFileExtFromMimeType(mimeType) {
+  // E.g. need to take into account stuff like: image/jpeg;extra-info, image/svg+xml.
+  // Grab everything after / until there is a non alphanumeric character.
+  const matches = mimeType.match(/(?<=\/)[a-zA-Z0-9]{1,}/i);
+  // Match will either return an array or null.
+  return matches !== null ? matches[0] : null;
+}

--- a/helpers/getImagesFromBlogBody.mjs
+++ b/helpers/getImagesFromBlogBody.mjs
@@ -3,10 +3,10 @@ import db from '../db/prismaClient.mjs';
 
 export default async function getImagesFromBlogBody(body) {
   // Find all instances of a markdown string.
-  const imageLinks = body.match(regexp.createStaticLinkRegExp('g'));
+  const imageLinks = body.match(regexp.createMarkdownStaticLinkRegExp('g'));
 
   // Extract file names from imageLinks with another regexp.
-  const linkRegExp = regexp.createStaticFileNameRegExp();
+  const linkRegExp = regexp.createFileNameRegExp();
   const fileNames = imageLinks
     ? imageLinks.map((link) => link.match(linkRegExp)[0])
     : [];

--- a/helpers/regexp.mjs
+++ b/helpers/regexp.mjs
@@ -1,4 +1,5 @@
-function createStaticLinkRegExp(flags) {
+function createMarkdownStaticLinkRegExp(flags) {
+  // For finding markdown links to static directory on server as determined by env variables.
   return new RegExp(
     // String given to RegExp needs to be DOUBLE ESCAPED. The first \ gets consumed by string parser.
     // If eslint gives a no-useless-escape character, then it probably means you need another backslash!
@@ -7,18 +8,19 @@ function createStaticLinkRegExp(flags) {
   );
 }
 
-function createStaticFileNameRegExp(flags) {
-  return new RegExp(`(?<=\\/)[^\\.\\/]+\\.\\w+`, flags);
-}
-
 function createMarkdownImgLinkRegExp(link, altText, flags) {
   // For matching ![my alt text](https://my-website.com/static/my-link.png), etc.
   // Makes it easy to match and replace the whole link.
   return new RegExp(`!\\[${altText || '.*?'}\\]\\(${link}\\)`, flags);
 }
 
+function createFileNameRegExp(flags) {
+  // For matching the filename at the end of a path.
+  return new RegExp(`(?<=\\/)[^\\.\\/]+\\.\\w+`, flags);
+}
+
 export {
-  createStaticLinkRegExp,
-  createStaticFileNameRegExp,
+  createMarkdownStaticLinkRegExp,
   createMarkdownImgLinkRegExp,
+  createFileNameRegExp,
 };

--- a/helpers/regexp.mjs
+++ b/helpers/regexp.mjs
@@ -11,4 +11,14 @@ function createStaticFileNameRegExp(flags) {
   return new RegExp(`(?<=\\/)[^\\.\\/]+\\.\\w+`, flags);
 }
 
-export { createStaticLinkRegExp, createStaticFileNameRegExp };
+function createMarkdownImgLinkRegExp(link, altText, flags) {
+  // For matching ![my alt text](https://my-website.com/static/my-link.png), etc.
+  // Makes it easy to match and replace the whole link.
+  return new RegExp(`!\\[${altText || '.*?'}\\]\\(${link}\\)`, flags);
+}
+
+export {
+  createStaticLinkRegExp,
+  createStaticFileNameRegExp,
+  createMarkdownImgLinkRegExp,
+};

--- a/middleware/multer.mjs
+++ b/middleware/multer.mjs
@@ -1,3 +1,4 @@
+import getFileExtFromMimeType from '../helpers/getFileExtFromMimeType.mjs';
 import multer from 'multer';
 
 const allowedUploadMimeTypes = JSON.parse(
@@ -11,8 +12,16 @@ const storage = multer.diskStorage({
     cb(null, process.env.VOLUME_MOUNT_PATH);
   },
   filename: (req, file, cb) => {
+    const fileExt = getFileExtFromMimeType(file.mimetype);
+    if (!fileExt) {
+      return cb(
+        new Error(
+          `Invalid mimetype: ${file.mimetype}. Could not extract file extension`,
+        ),
+      );
+    }
     const uniquePrefix = Date.now() + '-' + Math.round(Math.random() * 1e9);
-    cb(null, uniquePrefix + '-' + file.originalname);
+    cb(null, uniquePrefix + '.' + fileExt);
   },
 });
 

--- a/middleware/multer.mjs
+++ b/middleware/multer.mjs
@@ -1,5 +1,11 @@
 import multer from 'multer';
 
+const allowedUploadMimeTypes = JSON.parse(
+  process.env.UPLOAD_ALLOWED_MIME_TYPES,
+);
+
+const errorMsg = process.env.UPLOAD_MIME_TYPE_ERROR;
+
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
     cb(null, process.env.VOLUME_MOUNT_PATH);
@@ -10,4 +16,12 @@ const storage = multer.diskStorage({
   },
 });
 
-export default multer({ storage });
+const fileFilter = (req, file, cb) => {
+  if (allowedUploadMimeTypes.includes(file.mimetype)) {
+    return cb(null, true);
+  } else {
+    return cb(new Error(errorMsg), false);
+  }
+};
+
+export default multer({ storage, fileFilter });

--- a/middleware/multer.mjs
+++ b/middleware/multer.mjs
@@ -5,6 +5,8 @@ const allowedUploadMimeTypes = JSON.parse(
   process.env.UPLOAD_ALLOWED_MIME_TYPES,
 );
 
+const maxSizeBytes = process.env.UPLOAD_MAX_SIZE_MB * 1024 * 1024;
+
 const errorMsg = process.env.UPLOAD_MIME_TYPE_ERROR;
 
 const storage = multer.diskStorage({
@@ -33,4 +35,12 @@ const fileFilter = (req, file, cb) => {
   }
 };
 
-export default multer({ storage, fileFilter });
+const limits = {
+  fileSize: maxSizeBytes,
+};
+
+export default multer({
+  storage,
+  fileFilter,
+  limits,
+});


### PR DESCRIPTION
Fix a few things and improve security with image uploads.

- Fix invalid http links when images were uploaded with spaces and possibly other characters. Filenames are now 100% server generated so we can guarantee that no weird characters will be used, and the ```createStaticUrl``` function now uses the URL api to ensure the returned URL is properly formatted
- Remove user-dependent part of the filename to reduce probability of malicious users finding something to exploit
- Get filetype and extension from mimetype of upload instead of user-supplied filename, and filename can obviously be faked
- Limit upload size which is set in environment variables, otherwise some user could upload a million gigabytes of whatever and crash the system, or cause an influx of costs for the extra storage space, DDoS attacks, etc.
- Only allow uploads of certain file types, as determined by an array in the env file (turn into a js array with ```JSON.parse```)
- Check an image is not associated with any blogs before deleting it
- When an image is updated, automatically update any links in associated blogs, i.e. if an image file is replaced, the filename will be randomly generated and break the existing link. So now the image put method automatically replaces the existing link with the updated version